### PR TITLE
TASK-03: Define Insight TypeScript interface

### DIFF
--- a/packages/shared/src/types/insights.ts
+++ b/packages/shared/src/types/insights.ts
@@ -1,0 +1,28 @@
+/**
+ * Types of AI-generated insights.
+ */
+export type InsightType = 'summary' | 'trend' | 'anomaly';
+
+/**
+ * Represents an AI-generated analytics insight.
+ * Used to display intelligent analysis of tracking data.
+ */
+export interface Insight {
+  /** Unique identifier for the insight */
+  id: string;
+
+  /** ISO 8601 timestamp when the insight was generated */
+  generatedAt: string;
+
+  /** Category of the insight */
+  type: InsightType;
+
+  /** Brief title describing the insight */
+  title: string;
+
+  /** Detailed content/explanation of the insight */
+  content: string;
+
+  /** Additional context and data related to the insight */
+  metadata: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
Added the `Insight` TypeScript interface for AI-generated analytics insights in the shared package.

## Changes
- Created `packages/shared/src/types/insights.ts`
- Defined `InsightType` union type with three categories: summary, trend, anomaly
- Defined `Insight` interface with required fields: id, generatedAt, type, title, content, metadata

## Verification
The implementation follows the established patterns from the TrackingEvent interface and meets all acceptance criteria for TASK-03.