### PR TITLE
feat(shared): Export EventType enum from shared package

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,9 @@ export { TrackerConfig } from './types/tracker';
 export { Product } from './types/product';
 export { Cart, CartItem } from './types/cart';
 
+// Constants
+export { EventType } from './constants/eventTypes';
+
 // Data
 export { products } from './data/products';
 


### PR DESCRIPTION
## Summary
- Export EventType enum from `@flowtel/shared` package barrel file
- Makes the enum accessible to other packages (tracker, backend, shop, dashboard)

## Changes
The `EventType` enum was already defined in `packages/shared/src/constants/eventTypes.ts` but was not exported from the main `index.ts`. This PR adds the missing export.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] EventType is exported in dist/index.js and dist/index.d.ts
- [x] All 6 event types are available: PAGE_VIEW, PRODUCT_VIEWED, ADD_TO_CART, REMOVE_FROM_CART, CHECKOUT_STARTED, PURCHASE_COMPLETED

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)