### PR TITLE
feat(events): Create Event entity for database (#40)

### DIFF
--- a/packages/backend/src/events/entities/event.entity.ts
+++ b/packages/backend/src/events/entities/event.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  Column,
+  PrimaryColumn,
+  Index,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity('events')
+@Index(['shopId'])
+@Index(['eventType'])
+@Index(['timestamp'])
+export class Event {
+  @PrimaryColumn()
+  id!: string;
+
+  @Column()
+  shopId!: string;
+
+  @Column()
+  sessionId!: string;
+
+  @Column()
+  eventType!: string;
+
+  @Column()
+  eventName!: string;
+
+  @Column({ type: 'simple-json' })
+  properties!: Record<string, unknown>;
+
+  @Column()
+  timestamp!: string;
+
+  @Column()
+  url!: string;
+
+  @Column()
+  userAgent!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}


### PR DESCRIPTION
## Summary
Create the Event entity with TypeORM decorators to store tracking events in SQLite. Maps all TrackingEvent fields including properties (JSON), timestamps, and session data.

## Implementation
- Entity with all 9 TrackingEvent fields
- Primary key on `id`, indexes on `shopId`, `eventType`, `timestamp`
- Auto-generated `createdAt` timestamp via `@CreateDateColumn()`
- Properties stored as `simple-json` column for SQLite compatibility

## Testing
Build verified: `pnpm --filter @flowtel/backend build` passes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)