### PR TITLE
feat(backend): Create Insight entity for database storage

### DIFF
--- a/packages/backend/src/insights/entities/insight.entity.ts
+++ b/packages/backend/src/insights/entities/insight.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { Insight, InsightType } from '@flowtel/shared';
+
+@Entity('insights')
+@Index(['type'])
+@Index(['generatedAt'])
+export class InsightEntity implements Insight {
+  @PrimaryColumn('varchar')
+  id!: string;
+
+  @Column('datetime')
+  generatedAt!: string;
+
+  @Column('varchar')
+  type!: InsightType;
+
+  @Column('varchar')
+  title!: string;
+
+  @Column('text')
+  content!: string;
+
+  @Column('simple-json')
+  metadata!: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}


### PR DESCRIPTION
## Summary

Implement TypeORM entity for storing AI-generated insights with proper indexing and JSON metadata support.

## Changes

- Create InsightEntity with all fields from Insight interface (id, generatedAt, type, title, content, metadata)
- Add indexes on `type` and `generatedAt` columns for query performance
- Use `simple-json` column type for metadata to store flexible key-value data
- Add auto-timestamp for `createdAt` field

Closes #41