### PR TITLE
feat(backend): Implement StatsService for aggregations

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from './database/database.module';
 import { EventsModule } from './events/events.module';
+import { StatsModule } from './stats/stats.module';
 
 @Module({
-  imports: [DatabaseModule, EventsModule],
+  imports: [DatabaseModule, EventsModule, StatsModule],
   controllers: [],
   providers: [],
 })

--- a/packages/backend/src/stats/stats.module.ts
+++ b/packages/backend/src/stats/stats.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from '../events/entities/event.entity';
+import { StatsService } from './stats.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Event])],
+  providers: [StatsService],
+  exports: [StatsService],
+})
+export class StatsModule {}

--- a/packages/backend/src/stats/stats.service.ts
+++ b/packages/backend/src/stats/stats.service.ts
@@ -1,0 +1,165 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Stats, TopProduct, products } from '@flowtel/shared';
+import { Event } from '../events/entities/event.entity';
+
+interface EventCountResult {
+  eventType: string;
+  count: string;
+}
+
+interface RevenueResult {
+  totalRevenue: string | null;
+}
+
+interface ProductCountResult {
+  productId: string;
+  count: string;
+}
+
+interface SessionCountResult {
+  sessionCount: string;
+}
+
+@Injectable()
+export class StatsService {
+  private readonly productMap: Map<string, string>;
+
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+  ) {
+    this.productMap = new Map(products.map((p) => [p.id, p.name]));
+  }
+
+  async getStats(shopId: string): Promise<Stats> {
+    const [eventCounts, revenueResult, topProductsResult, conversionData] =
+      await Promise.all([
+        this.getEventCounts(shopId),
+        this.getTotalRevenue(shopId),
+        this.getTopProducts(shopId),
+        this.getConversionData(shopId),
+      ]);
+
+    const countsMap = new Map<string, number>(
+      eventCounts.map((r) => [r.eventType, Number(r.count)]),
+    );
+
+    const totalEvents = Array.from(countsMap.values()).reduce(
+      (sum, count) => sum + count,
+      0,
+    );
+
+    const totalProductViews = countsMap.get('product_viewed') || 0;
+
+    const conversionRate = this.calculateConversionRate(
+      conversionData.sessionsWithPurchases,
+      conversionData.sessionsWithProductViews,
+    );
+
+    return {
+      totalEvents,
+      totalPageViews: countsMap.get('page_view') || 0,
+      totalProductViews,
+      totalAddToCarts: countsMap.get('add_to_cart') || 0,
+      totalPurchases: countsMap.get('purchase_completed') || 0,
+      totalRevenue: Number(revenueResult?.totalRevenue) || 0,
+      conversionRate,
+      topProducts: this.mapTopProducts(topProductsResult),
+    };
+  }
+
+  private async getEventCounts(shopId: string): Promise<EventCountResult[]> {
+    return this.eventRepository
+      .createQueryBuilder('event')
+      .select('event.eventType', 'eventType')
+      .addSelect('COUNT(*)', 'count')
+      .where('event.shopId = :shopId', { shopId })
+      .groupBy('event.eventType')
+      .getRawMany<EventCountResult>();
+  }
+
+  private async getTotalRevenue(shopId: string): Promise<RevenueResult> {
+    const result = await this.eventRepository
+      .createQueryBuilder('event')
+      .select(
+        "COALESCE(SUM(json_extract(event.properties, '$.revenue')), 0)",
+        'totalRevenue',
+      )
+      .where('event.shopId = :shopId', { shopId })
+      .andWhere('event.eventType = :eventType', {
+        eventType: 'purchase_completed',
+      })
+      .getRawOne<RevenueResult>();
+
+    return result || { totalRevenue: null };
+  }
+
+  private async getTopProducts(
+    shopId: string,
+    limit: number = 10,
+  ): Promise<ProductCountResult[]> {
+    return this.eventRepository
+      .createQueryBuilder('event')
+      .select("json_extract(event.properties, '$.productId')", 'productId')
+      .addSelect('COUNT(*)', 'count')
+      .where('event.shopId = :shopId', { shopId })
+      .andWhere('event.eventType = :eventType', {
+        eventType: 'product_viewed',
+      })
+      .andWhere("json_extract(event.properties, '$.productId') IS NOT NULL")
+      .groupBy("json_extract(event.properties, '$.productId')")
+      .orderBy('count', 'DESC')
+      .limit(limit)
+      .getRawMany<ProductCountResult>();
+  }
+
+  private async getConversionData(shopId: string): Promise<{
+    sessionsWithProductViews: number;
+    sessionsWithPurchases: number;
+  }> {
+    const [productViewSessions, purchaseSessions] = await Promise.all([
+      this.eventRepository
+        .createQueryBuilder('event')
+        .select('COUNT(DISTINCT event.sessionId)', 'sessionCount')
+        .where('event.shopId = :shopId', { shopId })
+        .andWhere('event.eventType = :eventType', {
+          eventType: 'product_viewed',
+        })
+        .getRawOne<SessionCountResult>(),
+      this.eventRepository
+        .createQueryBuilder('event')
+        .select('COUNT(DISTINCT event.sessionId)', 'sessionCount')
+        .where('event.shopId = :shopId', { shopId })
+        .andWhere('event.eventType = :eventType', {
+          eventType: 'purchase_completed',
+        })
+        .getRawOne<SessionCountResult>(),
+    ]);
+
+    return {
+      sessionsWithProductViews: Number(productViewSessions?.sessionCount) || 0,
+      sessionsWithPurchases: Number(purchaseSessions?.sessionCount) || 0,
+    };
+  }
+
+  private calculateConversionRate(
+    sessionsWithPurchases: number,
+    sessionsWithProductViews: number,
+  ): number {
+    if (sessionsWithProductViews === 0) {
+      return 0;
+    }
+    const rate = (sessionsWithPurchases / sessionsWithProductViews) * 100;
+    return Math.round(rate * 100) / 100;
+  }
+
+  private mapTopProducts(results: ProductCountResult[]): TopProduct[] {
+    return results.map((result) => ({
+      productId: result.productId,
+      name: this.productMap.get(result.productId) || 'Unknown Product',
+      count: Number(result.count),
+    }));
+  }
+}


### PR DESCRIPTION
## Summary
- Implements `StatsService` with `getStats(shopId)` method for computing aggregated analytics metrics
- Creates `StatsModule` with TypeORM repository injection
- Integrates with AppModule

## Changes
- `packages/backend/src/stats/stats.service.ts` - Core stats aggregation logic
- `packages/backend/src/stats/stats.module.ts` - NestJS module definition
- `packages/backend/src/app.module.ts` - Import StatsModule

## Metrics Calculated
- `totalEvents` - Sum of all event counts
- `totalPageViews` - Count of page_view events
- `totalProductViews` - Count of product_viewed events
- `totalAddToCarts` - Count of add_to_cart events
- `totalPurchases` - Count of purchase_completed events
- `totalRevenue` - Sum of revenue from purchase events
- `conversionRate` - Sessions with purchases / Sessions with product views (%)
- `topProducts` - Top 10 products by view count with names

## Test plan
- [x] Build passes: `pnpm --filter @flowtel/backend build`
- [x] Tests pass: `pnpm --filter @flowtel/backend test`
- [x] Acceptance criteria verified against implementation

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)