### PR TITLE
feat(dashboard): Build StatsCard component for metric display

### DIFF
--- a/packages/dashboard/src/components/StatsCard/StatsCard.css
+++ b/packages/dashboard/src/components/StatsCard/StatsCard.css
@@ -1,0 +1,52 @@
+.stats-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease;
+}
+
+.stats-card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.stats-card__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
+}
+
+.stats-card__value {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: #1f2937;
+  line-height: 1.2;
+}
+
+.stats-card__trend {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.stats-card__trend--up {
+  color: #059669;
+}
+
+.stats-card__trend--down {
+  color: #dc2626;
+}
+
+.stats-card__trend-icon {
+  font-size: 0.75rem;
+}
+
+.stats-card__trend-value {
+  font-size: 0.875rem;
+}

--- a/packages/dashboard/src/components/StatsCard/StatsCard.tsx
+++ b/packages/dashboard/src/components/StatsCard/StatsCard.tsx
@@ -1,0 +1,51 @@
+import './StatsCard.css';
+
+interface StatsCardProps {
+  label: string;
+  value: number;
+  format?: 'number' | 'currency' | 'percentage';
+  trend?: {
+    value: number;
+    direction: 'up' | 'down';
+  };
+}
+
+function formatValue(value: number, format: 'number' | 'currency' | 'percentage'): string {
+  switch (format) {
+    case 'currency':
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      }).format(value);
+    case 'percentage':
+      return new Intl.NumberFormat('en-US', {
+        style: 'percent',
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }).format(value / 100);
+    case 'number':
+    default:
+      return new Intl.NumberFormat('en-US').format(value);
+  }
+}
+
+export function StatsCard({ label, value, format = 'number', trend }: StatsCardProps) {
+  const formattedValue = formatValue(value, format);
+
+  return (
+    <article className="stats-card">
+      <span className="stats-card__label">{label}</span>
+      <span className="stats-card__value">{formattedValue}</span>
+      {trend && (
+        <div className={`stats-card__trend stats-card__trend--${trend.direction}`}>
+          <span className="stats-card__trend-icon" aria-hidden="true">
+            {trend.direction === 'up' ? '↑' : '↓'}
+          </span>
+          <span className="stats-card__trend-value">
+            {trend.value > 0 ? '+' : ''}{trend.value.toFixed(1)}%
+          </span>
+        </div>
+      )}
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- Create reusable `StatsCard` component for displaying individual metrics in the dashboard
- Support different number formats: number, currency, and percentage via `Intl.NumberFormat`
- Add optional trend indicator with color coding (green for up, red for down)
- Use BEM CSS styling consistent with existing `ProductCard` patterns

## Test plan
- [ ] Run `pnpm build` to verify TypeScript compilation passes
- [ ] Import component in dashboard App.tsx to verify rendering
- [ ] Test all three format types (number, currency, percentage)
- [ ] Test with and without trend prop

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)