### PR TITLE
TASK-34: Create InsightCard component for dashboard

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@flowtel/shared": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/dashboard/src/components/InsightCard/InsightCard.css
+++ b/packages/dashboard/src/components/InsightCard/InsightCard.css
@@ -1,0 +1,81 @@
+.insight-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease;
+}
+
+.insight-card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.insight-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.insight-card__badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  border-radius: 9999px;
+}
+
+.insight-card__badge--summary {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+
+.insight-card__badge--trend {
+  background-color: #d1fae5;
+  color: #047857;
+}
+
+.insight-card__badge--anomaly {
+  background-color: #fef3c7;
+  color: #b45309;
+}
+
+.insight-card__timestamp {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.insight-card__title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1f2937;
+  line-height: 1.4;
+}
+
+.insight-card__content {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+@media (max-width: 480px) {
+  .insight-card {
+    padding: 1rem;
+  }
+
+  .insight-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .insight-card__title {
+    font-size: 1rem;
+  }
+}

--- a/packages/dashboard/src/components/InsightCard/InsightCard.tsx
+++ b/packages/dashboard/src/components/InsightCard/InsightCard.tsx
@@ -1,0 +1,45 @@
+import { Insight, InsightType } from '@flowtel/shared';
+import './InsightCard.css';
+
+interface InsightCardProps {
+  insight: Insight;
+}
+
+function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function getTypeLabel(type: InsightType): string {
+  const labels: Record<InsightType, string> = {
+    summary: 'Summary',
+    trend: 'Trend',
+    anomaly: 'Anomaly',
+  };
+  return labels[type];
+}
+
+export function InsightCard({ insight }: InsightCardProps) {
+  const { type, title, content, generatedAt } = insight;
+
+  return (
+    <article className="insight-card">
+      <header className="insight-card__header">
+        <span className={`insight-card__badge insight-card__badge--${type}`}>
+          {getTypeLabel(type)}
+        </span>
+        <time className="insight-card__timestamp" dateTime={generatedAt}>
+          {formatTimestamp(generatedAt)}
+        </time>
+      </header>
+      <h3 className="insight-card__title">{title}</h3>
+      <p className="insight-card__content">{content}</p>
+    </article>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
 
   packages/dashboard:
     dependencies:
+      '@flowtel/shared':
+        specifier: workspace:*
+        version: link:../shared
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
## Summary
- Create InsightCard component for displaying AI-generated insights
- Support three insight types with color-coded badges (summary, trend, anomaly)
- Display insight title, content, and generation timestamp
- Responsive card layout with hover effects

## Test plan
- [ ] Run `pnpm build` to verify compilation
- [ ] Run `pnpm dev:dashboard` and import InsightCard with mock data
- [ ] Verify all three badge types display correctly (summary=blue, trend=green, anomaly=orange)
- [ ] Test responsive behavior at mobile width (< 480px)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)