### PR TITLE
feat(backend): Implement InsightGenerationService (#78)

### DIFF
--- a/packages/backend/src/insights/application/insight-generation.service.ts
+++ b/packages/backend/src/insights/application/insight-generation.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Insight } from '@flowtel/shared';
+import { StatsService } from '../../stats/stats.service';
+import { LlmService } from '../../llm/llm.service';
+import { InsightsService } from '../insights.service';
+
+@Injectable()
+export class InsightGenerationService {
+  private readonly logger = new Logger(InsightGenerationService.name);
+
+  constructor(
+    private readonly statsService: StatsService,
+    private readonly llmService: LlmService,
+    private readonly insightsService: InsightsService,
+  ) {}
+
+  async generateInsights(shopId: string): Promise<Insight[]> {
+    this.logger.log(`Generating insights for shop: ${shopId}`);
+
+    // 1. Fetch aggregated stats (AC: fetches recent events)
+    const stats = await this.statsService.getStats(shopId);
+
+    // 2. Generate insights via LLM (AC: build prompt + parse response)
+    const insights = await this.llmService.generateInsight(stats);
+
+    // 3. Save each insight to database (AC: save to database)
+    const savedInsights: Insight[] = [];
+    for (const insight of insights) {
+      const saved = await this.insightsService.create(insight);
+      savedInsights.push(saved);
+    }
+
+    this.logger.log(`Generated and saved ${savedInsights.length} insights`);
+    return savedInsights;
+  }
+}

--- a/packages/backend/src/insights/insights.module.ts
+++ b/packages/backend/src/insights/insights.module.ts
@@ -2,10 +2,15 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { InsightEntity } from './entities/insight.entity';
 import { InsightsService } from './insights.service';
+import { InsightGenerationService } from './application/insight-generation.service';
+import { StatsModule } from '../stats/stats.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([InsightEntity])],
-  providers: [InsightsService],
-  exports: [InsightsService],
+  imports: [
+    TypeOrmModule.forFeature([InsightEntity]),
+    StatsModule,
+  ],
+  providers: [InsightsService, InsightGenerationService],
+  exports: [InsightsService, InsightGenerationService],
 })
 export class InsightsModule {}


### PR DESCRIPTION
## Summary
- Implements `InsightGenerationService` to orchestrate insight generation
- Fetches aggregated stats via `StatsService.getStats(shopId)`
- Generates insights via `LlmService.generateInsight(stats)`
- Persists insights to database via `InsightsService.create()`

## Test plan
- [x] Build passes: `pnpm build`
- [ ] Verify service initializes correctly when backend starts

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)