### PR TITLE
feat(dashboard): Create StatsOverview page for dashboard

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,4 +1,5 @@
 import { EventList } from './components/EventList';
+import { StatsOverview } from './pages/StatsOverview';
 import './App.css';
 
 function App() {
@@ -8,6 +9,7 @@ function App() {
         <h1 className="app__title">Flowtel Analytics Dashboard</h1>
       </header>
       <main className="app__main">
+        <StatsOverview />
         <EventList />
       </main>
     </div>

--- a/packages/dashboard/src/api/stats.ts
+++ b/packages/dashboard/src/api/stats.ts
@@ -1,0 +1,19 @@
+import { Stats } from '@flowtel/shared';
+import { apiClient } from './client';
+
+interface StatsQueryParams {
+  shopId?: string;
+}
+
+export async function fetchStats(params?: StatsQueryParams): Promise<Stats> {
+  const searchParams = new URLSearchParams();
+
+  if (params?.shopId) {
+    searchParams.append('shopId', params.shopId);
+  }
+
+  const queryString = searchParams.toString();
+  const endpoint = `/api/stats${queryString ? `?${queryString}` : ''}`;
+
+  return apiClient<Stats>(endpoint);
+}

--- a/packages/dashboard/src/hooks/useStats.ts
+++ b/packages/dashboard/src/hooks/useStats.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Stats } from '@flowtel/shared';
+import { fetchStats } from '../api/stats';
+
+interface UseStatsOptions {
+  shopId?: string;
+  autoRefreshInterval?: number;
+}
+
+interface UseStatsState {
+  stats: Stats | null;
+  isLoading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+}
+
+interface UseStatsReturn extends UseStatsState {
+  refresh: () => void;
+  setAutoRefresh: (enabled: boolean) => void;
+  isAutoRefreshEnabled: boolean;
+}
+
+const DEFAULT_REFRESH_INTERVAL = 30000;
+
+export function useStats(options?: UseStatsOptions): UseStatsReturn {
+  const { shopId, autoRefreshInterval = DEFAULT_REFRESH_INTERVAL } =
+    options ?? {};
+
+  const [state, setState] = useState<UseStatsState>({
+    stats: null,
+    isLoading: true,
+    error: null,
+    lastUpdated: null,
+  });
+
+  const [isAutoRefreshEnabled, setAutoRefreshEnabled] = useState(false);
+  const intervalRef = useRef<number | null>(null);
+
+  const loadStats = useCallback(async () => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const stats = await fetchStats({ shopId });
+      setState({
+        stats,
+        isLoading: false,
+        error: null,
+        lastUpdated: new Date(),
+      });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error: err instanceof Error ? err.message : 'Failed to load stats',
+      }));
+    }
+  }, [shopId]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  useEffect(() => {
+    if (isAutoRefreshEnabled && autoRefreshInterval > 0) {
+      intervalRef.current = window.setInterval(() => {
+        loadStats();
+      }, autoRefreshInterval);
+    }
+
+    return () => {
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [isAutoRefreshEnabled, autoRefreshInterval, loadStats]);
+
+  const refresh = useCallback(() => {
+    loadStats();
+  }, [loadStats]);
+
+  const setAutoRefresh = useCallback((enabled: boolean) => {
+    setAutoRefreshEnabled(enabled);
+  }, []);
+
+  return {
+    ...state,
+    refresh,
+    setAutoRefresh,
+    isAutoRefreshEnabled,
+  };
+}

--- a/packages/dashboard/src/pages/StatsOverview.css
+++ b/packages/dashboard/src/pages/StatsOverview.css
@@ -1,0 +1,155 @@
+.stats-overview {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.stats-overview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.stats-overview__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0;
+}
+
+.stats-overview__controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.stats-overview__auto-refresh {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.stats-overview__auto-refresh-checkbox {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+}
+
+.stats-overview__auto-refresh-label {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.stats-overview__refresh-button {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #3b82f6;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.stats-overview__refresh-button:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.stats-overview__refresh-button:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.stats-overview__last-updated {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.stats-overview__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+
+.stats-overview__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: #6b7280;
+}
+
+.stats-overview__spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: stats-overview-spin 0.8s linear infinite;
+}
+
+@keyframes stats-overview-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.stats-overview__error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  color: #dc2626;
+}
+
+.stats-overview__error-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background-color: #dc2626;
+  color: #ffffff;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+@media (max-width: 1024px) {
+  .stats-overview__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .stats-overview {
+    padding: 1rem;
+  }
+
+  .stats-overview__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-overview__controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .stats-overview__grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/packages/dashboard/src/pages/StatsOverview.tsx
+++ b/packages/dashboard/src/pages/StatsOverview.tsx
@@ -1,0 +1,108 @@
+import { StatsCard } from '../components/StatsCard/StatsCard';
+import { useStats } from '../hooks/useStats';
+import './StatsOverview.css';
+
+interface StatsOverviewProps {
+  shopId?: string;
+}
+
+export function StatsOverview({ shopId }: StatsOverviewProps) {
+  const {
+    stats,
+    isLoading,
+    error,
+    lastUpdated,
+    refresh,
+    setAutoRefresh,
+    isAutoRefreshEnabled,
+  } = useStats({ shopId });
+
+  const handleAutoRefreshToggle = () => {
+    setAutoRefresh(!isAutoRefreshEnabled);
+  };
+
+  const formatLastUpdated = (date: Date | null): string => {
+    if (!date) return '';
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  };
+
+  return (
+    <section className="stats-overview" aria-label="Statistics overview">
+      <div className="stats-overview__header">
+        <h2 className="stats-overview__title">Overview</h2>
+        <div className="stats-overview__controls">
+          <label className="stats-overview__auto-refresh">
+            <input
+              type="checkbox"
+              checked={isAutoRefreshEnabled}
+              onChange={handleAutoRefreshToggle}
+              className="stats-overview__auto-refresh-checkbox"
+            />
+            <span className="stats-overview__auto-refresh-label">
+              Auto-refresh
+            </span>
+          </label>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={isLoading}
+            className="stats-overview__refresh-button"
+            aria-label="Refresh statistics"
+          >
+            {isLoading ? 'Refreshing...' : 'Refresh'}
+          </button>
+          {lastUpdated && (
+            <span className="stats-overview__last-updated">
+              Last updated: {formatLastUpdated(lastUpdated)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {isLoading && !stats && (
+        <div className="stats-overview__loading" aria-live="polite">
+          <div className="stats-overview__spinner" aria-hidden="true" />
+          <span>Loading statistics...</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="stats-overview__error" role="alert">
+          <span className="stats-overview__error-icon" aria-hidden="true">
+            !
+          </span>
+          <span>{error}</span>
+        </div>
+      )}
+
+      {stats && (
+        <div className="stats-overview__grid">
+          <StatsCard
+            label="Total Events"
+            value={stats.totalEvents}
+            format="number"
+          />
+          <StatsCard
+            label="Purchases"
+            value={stats.totalPurchases}
+            format="number"
+          />
+          <StatsCard
+            label="Revenue"
+            value={stats.totalRevenue}
+            format="currency"
+          />
+          <StatsCard
+            label="Conversion Rate"
+            value={stats.conversionRate}
+            format="percentage"
+          />
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `api/stats.ts` - API function to fetch stats from `/api/stats` endpoint
- Create `useStats` hook with auto-refresh capability (30s interval, togglable)
- Build `StatsOverview` page with 4 metric cards grid (events, purchases, revenue, conversion)
- Implement loading spinner, error states, and manual refresh button
- Add responsive CSS grid layout (4 -> 2 -> 1 columns)

## Test plan
- [ ] Run `pnpm dev:dashboard` and verify StatsOverview renders above EventsPage
- [ ] Verify loading spinner appears on initial load
- [ ] Verify error state shows (until backend stats endpoint is implemented)
- [ ] Test responsive layout at different viewport widths (desktop/tablet/mobile)
- [ ] Test auto-refresh toggle checkbox enables/disables auto-refresh
- [ ] Test manual refresh button triggers data reload

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)