### PR TITLE
feat(backend): Implement GET /api/events endpoint

### DIFF
--- a/packages/backend/src/events/events.controller.ts
+++ b/packages/backend/src/events/events.controller.ts
@@ -11,13 +11,18 @@ import {
   CreateEventDto,
   EventsQueryDto,
   PaginatedResponseDto,
+  TrackingEvent,
 } from '@flowtel/shared';
 import { EventsService } from './events.service';
+import { EventQueryService } from './application/event-query.service';
 import { Event } from './entities/event.entity';
 
 @Controller('api/events')
 export class EventsController {
-  constructor(private readonly eventsService: EventsService) {}
+  constructor(
+    private readonly eventsService: EventsService,
+    private readonly eventQueryService: EventQueryService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
@@ -33,7 +38,7 @@ export class EventsController {
   @Get()
   async findAll(
     @Query() query: EventsQueryDto,
-  ): Promise<PaginatedResponseDto<Event>> {
-    return this.eventsService.findAll(query);
+  ): Promise<PaginatedResponseDto<TrackingEvent>> {
+    return this.eventQueryService.getEvents(query);
   }
 }


### PR DESCRIPTION
## Summary
- Wired EventsController GET endpoint to use EventQueryService as specified in acceptance criteria
- Updated return type to TrackingEvent DTOs for cleaner API response
- All query filters (eventType, shopId, startDate, endDate) supported via EventQueryService

## Test plan
- [ ] Run `pnpm test:backend` to verify backend tests pass
- [ ] Start backend with `pnpm dev:backend`
- [ ] Test endpoint: `curl "http://localhost:4000/api/events?limit=5"`
- [ ] Verify response contains `data`, `total`, `page`, `limit`, `totalPages`

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)