### PR TITLE
feat(backend): Implement POST /api/chat endpoint

### DIFF
--- a/packages/backend/src/chat/chat.controller.ts
+++ b/packages/backend/src/chat/chat.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ChatRequestDto, ChatResponseDto } from '@flowtel/shared';
+import { ChatService } from './chat.service';
+import { LlmServiceError } from '../llm/llm.service';
+
+@Controller('api/chat')
+export class ChatController {
+  private readonly logger = new Logger(ChatController.name);
+
+  constructor(private readonly chatService: ChatService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async chat(@Body() dto: ChatRequestDto): Promise<ChatResponseDto> {
+    const shopId = dto.shopId || 'default';
+
+    try {
+      return await this.chatService.askQuestion(
+        dto.message,
+        shopId,
+        dto.conversationId,
+      );
+    } catch (error) {
+      if (error instanceof LlmServiceError) {
+        this.logger.error('LLM service error during chat', error.message);
+        throw new InternalServerErrorException(
+          'Failed to process your question. Please try again later.',
+        );
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/backend/src/chat/chat.module.ts
+++ b/packages/backend/src/chat/chat.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
 import { StatsModule } from '../stats/stats.module';
 import { EventsModule } from '../events/events.module';
@@ -6,6 +7,7 @@ import { InsightsModule } from '../insights/insights.module';
 
 @Module({
   imports: [StatsModule, EventsModule, InsightsModule],
+  controllers: [ChatController],
   providers: [ChatService],
   exports: [ChatService],
 })


### PR DESCRIPTION
## Summary
- Adds `ChatController` with POST `/api/chat` endpoint for natural language analytics queries
- Accepts `ChatRequestDto` with `message`, optional `shopId`, and `conversationId`
- Returns `ChatResponseDto` with AI-generated answer, conversation ID, and sources
- Handles `LlmServiceError` gracefully with user-friendly error message

## Test plan
- [ ] Build succeeds: `pnpm build`
- [ ] POST `/api/chat` accepts questions and returns answers
- [ ] Endpoint returns 500 with safe message when LLM service fails

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)