### PR TITLE
feat(backend): Implement POST /api/insights/generate endpoint

### DIFF
--- a/packages/backend/src/insights/insights.controller.ts
+++ b/packages/backend/src/insights/insights.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  HttpException,
+  Logger,
+} from '@nestjs/common';
+import { Insight, InsightGenerateRequestDto } from '@flowtel/shared';
+import { InsightGenerationService } from './application/insight-generation.service';
+import { LlmServiceError } from '../llm/llm.service';
+
+@Controller('api/insights')
+export class InsightsController {
+  private readonly logger = new Logger(InsightsController.name);
+
+  constructor(
+    private readonly insightGenerationService: InsightGenerationService,
+  ) {}
+
+  @Post('generate')
+  @HttpCode(HttpStatus.CREATED)
+  async generate(@Body() dto: InsightGenerateRequestDto): Promise<Insight[]> {
+    const shopId = dto.shopId || 'default';
+
+    try {
+      this.logger.log(`Generating insights for shop: ${shopId}`);
+      const insights =
+        await this.insightGenerationService.generateInsights(shopId);
+      return insights;
+    } catch (error) {
+      if (error instanceof LlmServiceError) {
+        const message = error.message.toLowerCase();
+        if (
+          message.includes('rate') ||
+          message.includes('timeout') ||
+          message.includes('unavailable')
+        ) {
+          this.logger.warn(`LLM service unavailable: ${error.message}`);
+          throw new HttpException(
+            { message: 'LLM service temporarily unavailable', error: error.message },
+            HttpStatus.SERVICE_UNAVAILABLE,
+          );
+        }
+
+        this.logger.error(`LLM service error: ${error.message}`);
+        throw new HttpException(
+          { message: 'Failed to generate insights', error: error.message },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      this.logger.error('Unexpected error generating insights', error);
+      throw new HttpException(
+        { message: 'Failed to generate insights' },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/packages/backend/src/insights/insights.module.ts
+++ b/packages/backend/src/insights/insights.module.ts
@@ -4,6 +4,7 @@ import { InsightEntity } from './entities/insight.entity';
 import { InsightRepository } from './infrastructure/insight.repository';
 import { InsightsService } from './insights.service';
 import { InsightGenerationService } from './application/insight-generation.service';
+import { InsightsController } from './insights.controller';
 import { StatsModule } from '../stats/stats.module';
 
 @Module({
@@ -11,6 +12,7 @@ import { StatsModule } from '../stats/stats.module';
     TypeOrmModule.forFeature([InsightEntity]),
     StatsModule,
   ],
+  controllers: [InsightsController],
   providers: [InsightsService, InsightRepository, InsightGenerationService],
   exports: [InsightsService, InsightRepository, InsightGenerationService],
 })


### PR DESCRIPTION
## Summary
- Add `InsightsController` with POST /api/insights/generate endpoint
- Integrate with existing `InsightGenerationService` to trigger LLM-powered insight generation
- Handle LLM errors gracefully, returning 503 for rate limits/timeouts and 500 for other failures

## Closes
Closes #97

## Test plan
- [ ] Run `pnpm test:backend` to verify tests pass
- [ ] Start backend with `pnpm dev:backend`
- [ ] Test endpoint with: `curl -X POST http://localhost:4000/api/insights/generate -H "Content-Type: application/json" -d '{"shopId": "shop_123"}'`
- [ ] Verify 201 response with insights array
- [ ] Verify error handling returns appropriate status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)