### PR TITLE
feat(backend): Implement GET /api/stats endpoint (#95)

### DIFF
--- a/packages/backend/src/chat/chat.service.ts
+++ b/packages/backend/src/chat/chat.service.ts
@@ -25,7 +25,7 @@ export class ChatService {
     const convId = conversationId || randomUUID();
 
     const [stats, eventsResult, insights] = await Promise.all([
-      this.statsService.getStats(shopId),
+      this.statsService.getStats({ shopId }),
       this.eventsService.findAll({ shopId, limit: 50 }),
       this.insightsService.findRecent(5),
     ]);

--- a/packages/backend/src/insights/application/insight-generation.service.ts
+++ b/packages/backend/src/insights/application/insight-generation.service.ts
@@ -18,7 +18,7 @@ export class InsightGenerationService {
     this.logger.log(`Generating insights for shop: ${shopId}`);
 
     // 1. Fetch aggregated stats (AC: fetches recent events)
-    const stats = await this.statsService.getStats(shopId);
+    const stats = await this.statsService.getStats({ shopId });
 
     // 2. Generate insights via LLM (AC: build prompt + parse response)
     const insights = await this.llmService.generateInsight(stats);

--- a/packages/backend/src/stats/stats.controller.ts
+++ b/packages/backend/src/stats/stats.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { Stats, StatsQueryDto } from '@flowtel/shared';
+import { StatsService } from './stats.service';
+
+@Controller('api/stats')
+export class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  async getStats(@Query() query: StatsQueryDto): Promise<Stats> {
+    return this.statsService.getStats(query);
+  }
+}

--- a/packages/backend/src/stats/stats.module.ts
+++ b/packages/backend/src/stats/stats.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Event } from '../events/entities/event.entity';
+import { StatsController } from './stats.controller';
 import { StatsService } from './stats.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Event])],
+  controllers: [StatsController],
   providers: [StatsService],
   exports: [StatsService],
 })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,4 +21,5 @@ export {
   ChatResponseDto,
   InsightGenerateRequestDto,
   PaginatedResponseDto,
+  StatsQueryDto,
 } from './types/api';

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -136,3 +136,18 @@ export interface PaginatedResponseDto<T> {
   /** Total number of pages */
   totalPages: number;
 }
+
+/**
+ * DTO for querying/filtering stats.
+ * Used for GET /api/stats endpoint.
+ */
+export interface StatsQueryDto {
+  /** Filter by shop ID */
+  shopId?: string;
+
+  /** Filter stats after this date (ISO 8601) */
+  startDate?: string;
+
+  /** Filter stats before this date (ISO 8601) */
+  endDate?: string;
+}


### PR DESCRIPTION
## Summary
- Implements GET /api/stats endpoint for retrieving aggregated statistics
- Adds optional filtering by shopId and date range (startDate, endDate)
- Adds StatsQueryDto to shared types for type-safe query parameters
- Updates StatsService with flexible filtering using query builder pattern

## Acceptance Criteria
- [x] Optional shopId query param
- [x] Optional date range params (startDate, endDate)
- [x] Call StatsAggregationService (StatsService)
- [x] Return 200 with Stats object

## Test plan
- Build passes: `pnpm build`
- Test endpoint with:
  - `GET /api/stats` (no filters)
  - `GET /api/stats?shopId=shop_123`
  - `GET /api/stats?startDate=2024-01-01&endDate=2024-12-31`
  - `GET /api/stats?shopId=shop_123&startDate=2024-01-01&endDate=2024-12-31`

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)