### PR TITLE
feat(dashboard): Create centralized API client service (#105)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,14 +149,28 @@ VITE_API_URL=http://localhost:4000
 | `@flowtel/shared` | ✅ Complete | Types, DTOs, EventType enum, mock products |
 | `@flowtel/tracker` | ✅ Functional | init, track, HTTP send with retry, auto page views |
 | `@flowtel/shop` | ✅ Functional | Product list, detail, cart, checkout, order confirmation, tracker integration |
-| `@flowtel/backend` | 🟡 Partial | Database, Event entity, Events service (needs controller) |
-| `@flowtel/dashboard` | ⏳ Scaffold | Basic React app only |
+| `@flowtel/backend` | ✅ Functional | Database, Event entity, Events/Stats/Insights/Chat controllers |
+| `@flowtel/dashboard` | 🟡 Partial | Basic React app, API client service, Stats/Events/Insights/Chat UI |
+
+### Dashboard API Client
+
+The dashboard uses a centralized API client service at `packages/dashboard/src/services/api.ts`:
+
+```typescript
+import { apiService } from './services/api';
+
+// Available methods:
+apiService.getStats(params?)           // GET /api/stats
+apiService.getEvents(filters)          // GET /api/events
+apiService.getInsights(filters?)       // GET /api/insights
+apiService.generateInsights(request?)  // POST /api/insights/generate
+apiService.sendChatMessage(request)    // POST /api/chat
+```
 
 ### Next Steps
-1. Add Events controller to backend (POST/GET `/api/events`)
-2. ~~Integrate tracker into shop~~ ✅ Done (TASK-68)
-3. Build dashboard UI (stats, charts, event list)
-4. Add AI insights generation
+1. ~~Integrate tracker into shop~~ ✅ Done (TASK-68)
+2. Build more dashboard UI components (charts, visualizations)
+3. Enhance AI insights generation
 
 ## Key Decisions
 

--- a/packages/dashboard/src/components/ChatInterface/ChatInterface.tsx
+++ b/packages/dashboard/src/components/ChatInterface/ChatInterface.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { ChatRequestDto, ChatResponseDto, ChatSource } from '@flowtel/shared';
+import { ChatSource } from '@flowtel/shared';
+import { apiService } from '../../services/api';
 import './ChatInterface.css';
 
 interface Message {
@@ -9,8 +10,6 @@ interface Message {
   timestamp: Date;
   sources?: ChatSource[];
 }
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
 function generateId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
@@ -51,24 +50,10 @@ export function ChatInterface() {
     setIsLoading(true);
 
     try {
-      const requestBody: ChatRequestDto = {
+      const data = await apiService.sendChatMessage({
         message: trimmedInput,
         conversationId,
-      };
-
-      const response = await fetch(`${API_URL}/api/chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
       });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data: ChatResponseDto = await response.json();
 
       const assistantMessage: Message = {
         id: generateId(),

--- a/packages/dashboard/src/services/api.ts
+++ b/packages/dashboard/src/services/api.ts
@@ -1,0 +1,113 @@
+import {
+  ChatRequestDto,
+  ChatResponseDto,
+  EventsQueryDto,
+  Insight,
+  InsightGenerateRequestDto,
+  InsightsQueryDto,
+  InsightType,
+  PaginatedResponseDto,
+  Stats,
+  StatsQueryDto,
+  TrackingEvent,
+} from '@flowtel/shared';
+import { apiClient, ApiError } from '../api/client';
+
+export { ApiError };
+
+interface InsightsQueryParams {
+  type?: InsightType;
+  page?: number;
+  limit?: number;
+}
+
+export const apiService = {
+  /**
+   * Fetch aggregated statistics.
+   * GET /api/stats
+   */
+  async getStats(params?: StatsQueryDto): Promise<Stats> {
+    const searchParams = new URLSearchParams();
+
+    if (params?.shopId) {
+      searchParams.append('shopId', params.shopId);
+    }
+    if (params?.startDate) {
+      searchParams.append('startDate', params.startDate);
+    }
+    if (params?.endDate) {
+      searchParams.append('endDate', params.endDate);
+    }
+
+    const queryString = searchParams.toString();
+    const endpoint = `/api/stats${queryString ? `?${queryString}` : ''}`;
+
+    return apiClient<Stats>(endpoint);
+  },
+
+  /**
+   * Fetch events with optional filters.
+   * GET /api/events
+   */
+  async getEvents(
+    filters: EventsQueryDto,
+  ): Promise<PaginatedResponseDto<TrackingEvent>> {
+    const params = new URLSearchParams();
+
+    if (filters.shopId) params.append('shopId', filters.shopId);
+    if (filters.sessionId) params.append('sessionId', filters.sessionId);
+    if (filters.eventType) params.append('eventType', filters.eventType);
+    if (filters.startDate) params.append('startDate', filters.startDate);
+    if (filters.endDate) params.append('endDate', filters.endDate);
+    if (filters.page) params.append('page', filters.page.toString());
+    if (filters.limit) params.append('limit', filters.limit.toString());
+
+    const queryString = params.toString();
+    const endpoint = `/api/events${queryString ? `?${queryString}` : ''}`;
+
+    return apiClient<PaginatedResponseDto<TrackingEvent>>(endpoint);
+  },
+
+  /**
+   * Fetch generated insights with optional filters.
+   * GET /api/insights
+   */
+  async getInsights(
+    filters: InsightsQueryParams = {},
+  ): Promise<PaginatedResponseDto<Insight>> {
+    const params = new URLSearchParams();
+
+    if (filters.type) params.append('type', filters.type);
+    if (filters.page) params.append('page', filters.page.toString());
+    if (filters.limit) params.append('limit', filters.limit.toString());
+
+    const queryString = params.toString();
+    const endpoint = `/api/insights${queryString ? `?${queryString}` : ''}`;
+
+    return apiClient<PaginatedResponseDto<Insight>>(endpoint);
+  },
+
+  /**
+   * Trigger insight generation.
+   * POST /api/insights/generate
+   */
+  async generateInsights(
+    request: InsightGenerateRequestDto = {},
+  ): Promise<Insight[]> {
+    return apiClient<Insight[]>('/api/insights/generate', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  },
+
+  /**
+   * Send a chat message about analytics data.
+   * POST /api/chat
+   */
+  async sendChatMessage(request: ChatRequestDto): Promise<ChatResponseDto> {
+    return apiClient<ChatResponseDto>('/api/chat', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- Create centralized API client service at `packages/dashboard/src/services/api.ts`
- Implement all required methods: `getStats()`, `getEvents()`, `getInsights()`, `generateInsights()`, `sendChatMessage()`
- Refactor ChatInterface component to use the new centralized service instead of inline fetch

## Acceptance Criteria
- [x] Configure base URL from environment (reuses existing `api/client.ts`)
- [x] getStats() method
- [x] getEvents() method with filters
- [x] getInsights() method
- [x] generateInsights() method
- [x] sendChatMessage() method

## Test plan
- [x] Build succeeds: `pnpm build` (dashboard package)
- [ ] Manual test: Start backend and dashboard, navigate to Chat page and verify chat functionality works via the new service

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)