### PR TITLE
feat(backend): Configure CORS with environment variable support (TASK-80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ pnpm lint             # Lint all packages
 DATABASE_URL=sqlite:./data.db
 OPENAI_API_KEY=sk-...
 PORT=4000
+CORS_ORIGINS=http://localhost:3000,http://localhost:3001,http://localhost:5173  # Comma-separated, optional
 
 # Shop
 VITE_API_URL=http://localhost:4000
@@ -149,7 +150,7 @@ VITE_API_URL=http://localhost:4000
 | `@flowtel/shared` | ✅ Complete | Types, DTOs, EventType enum, mock products |
 | `@flowtel/tracker` | ✅ Functional | init, track, HTTP send with retry, auto page views |
 | `@flowtel/shop` | ✅ Functional | Product list, detail (with tracking), cart (with tracking), checkout (checkout_started, purchase_completed events), order confirmation, tracker integration |
-| `@flowtel/backend` | ✅ Functional | Database, Event entity, Events/Stats/Insights/Chat controllers |
+| `@flowtel/backend` | ✅ Functional | Database, Event entity, Events/Stats/Insights/Chat controllers, CORS configuration |
 | `@flowtel/dashboard` | 🟡 Partial | Basic React app, API client service, Stats/Events/Insights/Chat UI, StatsOverview connected to backend |
 
 ### Dashboard API Client
@@ -197,6 +198,13 @@ The shop uses a vite alias to import tracker source directly:
 - `vite.config.ts`: Alias `@flowtel/tracker` to `../tracker/src/index.ts`
 - `tsconfig.json`: Path mapping for TypeScript resolution
 - `CartContext.tsx`: Tracks `add_to_cart` and `remove_from_cart` events
+
+### Backend CORS Configuration
+CORS is configured in `packages/backend/src/main.ts`:
+- **Default origins**: localhost:3000 (shop), localhost:3001 (dashboard), localhost:5173 (Vite dev)
+- **Environment variable**: Set `CORS_ORIGINS` to override defaults (comma-separated list)
+- **Methods allowed**: GET, POST, PUT, DELETE, PATCH, OPTIONS
+- **Credentials**: Enabled
 
 ## Key Decisions
 

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,0 +1,13 @@
+# CORS Configuration (comma-separated list of allowed origins)
+# If not set, defaults to localhost:3000, localhost:3001, localhost:5173
+CORS_ORIGINS=http://localhost:3000,http://localhost:3001,http://localhost:5173
+
+# Server
+PORT=4000
+
+# Database
+DATABASE_URL=sqlite:./data.db
+
+# LLM (choose one)
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -4,13 +4,21 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  const defaultOrigins = [
+    'http://localhost:3000',
+    'http://localhost:3001',
+    'http://localhost:5173',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:3001',
+    'http://127.0.0.1:5173',
+  ];
+
+  const origins = process.env.CORS_ORIGINS
+    ? process.env.CORS_ORIGINS.split(',').map((o) => o.trim())
+    : defaultOrigins;
+
   app.enableCors({
-    origin: [
-      'http://localhost:3000',
-      'http://localhost:5173',
-      'http://127.0.0.1:3000',
-      'http://127.0.0.1:5173',
-    ],
+    origin: origins,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     credentials: true,
   });


### PR DESCRIPTION
## Summary
- Add localhost:3001 (dashboard) to allowed CORS origins
- Add CORS_ORIGINS environment variable for custom origin configuration
- Create .env.example with documented environment variables
- Update CLAUDE.md with CORS configuration documentation

## Test plan
- [ ] Start backend with `pnpm dev:backend`
- [ ] Verify CORS headers allow requests from localhost:3000, localhost:3001, localhost:5173
- [ ] Test with custom CORS_ORIGINS environment variable
- [ ] Verify backend builds successfully

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)