### PR TITLE
docs: Mark TASK-84 ChatModule as complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,9 @@ The shop tracks the following events:
 2. ~~Add tracking to ProductList~~ ✅ Done (TASK-69)
 3. ~~Connect StatsOverview to backend~~ ✅ Done (TASK-74)
 4. ~~Connect EventsPage to backend API~~ ✅ Done (TASK-75)
-5. Build more dashboard UI components (charts, visualizations)
-6. Enhance AI insights generation
+5. ~~Create NestJS ChatModule~~ ✅ Done (TASK-84) - ChatModule with ChatService and ChatController fully implemented
+6. Build more dashboard UI components (charts, visualizations)
+7. Enhance AI insights generation
 
 ### Dashboard EventsPage Integration
 The EventsPage is fully integrated with the backend API:


### PR DESCRIPTION
## Summary
- Verified that ChatModule (TASK-84) was already fully implemented at `packages/backend/src/chat/chat.module.ts`
- Updated CLAUDE.md to reflect TASK-84 completion in Next Steps section
- Closed GitHub issue #116

## Details
The ChatModule already exists with:
- ChatService in providers array
- ChatController registered
- StatsModule, EventsModule, InsightsModule imported
- LlmService accessible via @Global() LlmModule

## Test plan
- [x] Backend build verified successfully
- [x] ChatModule functional - uses NestJS best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)